### PR TITLE
Added deprecation warning for Puppet >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ For PE Puppet Server:
 
 This uses gem as a parent and uses the PE version of the
 `puppetserver gem` command for all gem operations.
+
+## Deprecation for Puppet >= 4.0
+
+As of Puppet 4.0, this module has been deprecated. Please use the puppet_gem provider instead.

--- a/lib/puppet/provider/package/pe_puppetserver_gem.rb
+++ b/lib/puppet/provider/package/pe_puppetserver_gem.rb
@@ -13,6 +13,14 @@ Puppet::Type.type(:package).provide :pe_puppetserver_gem, :parent => :gem do
 
   commands :puppetservercmd => "/opt/puppet/bin/puppetserver"
 
+  def self.instances
+    if Puppet[:version].to_f >= 4.0
+      warn "DEPRECATION: As of Puppet 4.0, the pe_puppetserver_gem provider for the package resource has been deprecated. Please use the puppetserver_gem provider instead."
+    end
+
+    super
+  end
+
   def self.gemlist(options)
     gem_list_command = [command(:puppetservercmd), "gem", "list"]
 


### PR DESCRIPTION
This is untested as I can't seem to be able to obtain a shallow gravey (PE4) release with Puppet 4 installed.